### PR TITLE
Adding data to id-pr-data for test in java-8-lambdas-exercises

### DIFF
--- a/id-pr-data.csv
+++ b/id-pr-data.csv
@@ -112,7 +112,7 @@ https://github.com/raphw/byte-buddy,505b9bb02920c6f5d8662ce310f9568acd1e5baf,byt
 https://github.com/raphw/byte-buddy,505b9bb02920c6f5d8662ce310f9568acd1e5baf,byte-buddy-dep,net.bytebuddy.dynamic.scaffold.MethodGraphCompilerDefaultTest.testGenericNonOverriddenInterfaceImplementation,ID,,,
 https://github.com/raphw/byte-buddy,505b9bb02920c6f5d8662ce310f9568acd1e5baf,byte-buddy-dep,net.bytebuddy.implementation.auxiliary.MethodCallProxyTest.testNonGenericParameter,ID,,,
 https://github.com/raphw/byte-buddy,505b9bb02920c6f5d8662ce310f9568acd1e5baf,byte-buddy-dep,net.bytebuddy.pool.TypePoolDefaultMethodDescriptionTest.testExceptions,ID,,,
-https://github.com/RichardWarburton/java-8-lambdas-exercises,87fdadf617461dcd22badbd6f69a457e37e1c42f,.,com.insightfullogic.java8.examples.chapter3.RefactorTest.allStringJoins,ID,,,
+https://github.com/RichardWarburton/java-8-lambdas-exercises,87fdadf617461dcd22badbd6f69a457e37e1c42f,.,com.insightfullogic.java8.examples.chapter3.RefactorTest.allStringJoins,ID,Opened,https://github.com/RichardWarburton/java-8-lambdas-exercises/pull/47,
 https://github.com/robovm/robovm,ef091902377c00dc0fb2db87e8d79c8afb5e9010,llvm,org.robovm.llvm.ObjectFileTest.testLineNumberInfo,ID,,,
 https://github.com/searchbox-io/Jest,c4ded4f49a06f284fdf53cb23e84ca041c6596dd,jest-common,io.searchbox.indices.RolloverTest.testBasicUriGeneration,ID,,,
 https://github.com/searchbox-io/Jest,c4ded4f49a06f284fdf53cb23e84ca041c6596dd,jest-common,io.searchbox.indices.RolloverTest.testBasicUriWithSettingsGeneration,ID,,,


### PR DESCRIPTION
This test passes when run without NonDex, fails without.

I discovered that this is caused by indeterminant order of items in a HashSet.

[PR for fix](https://github.com/RichardWarburton/java-8-lambdas-exercises/pull/47)